### PR TITLE
Fix a routing bug

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,11 +43,11 @@ function App() {
           spDrawerState={spDrawerState}
           onChangeSpDrawerState={setSpDrawerState}
         >
-          <Route exact path="/">
+          <Route exact path="/map">
             <p>Welcome to Geisen Map!</p>
           </Route>
           <Route
-            path="/gamecenter/:gamecenterId"
+            path="/map/gamecenter/:gamecenterId"
             render={(routeProps) => (
               <GameCenterInfo
                 {...routeProps}


### PR DESCRIPTION
The gamecenter info wasn't displayed due to a wrong routing.

<Route path="a">
  <Route path="b" component={B} /> // must be a/b here to render B
</Route>